### PR TITLE
Fix version check to compare minor version

### DIFF
--- a/lib/zipper.js
+++ b/lib/zipper.js
@@ -1,8 +1,14 @@
 var assert = require('assert');
 var zipper = require('../build/Release/zipper');
 
+function minorVersion(version) {
+  return version.split('.').slice(0, 2).join('.');
+}
+
 /* assert ABI compatibility */
-assert.ok(zipper.versions.node === process.versions.node, 'The running node version "' + process.versions.node + '" does not match the node version that zipper was compiled against: "' + zipper.versions.node + '"');
+var zipperMinor = minorVersion(zipper.versions.node);
+var nodeMinor = minorVersion(process.versions.node);
+assert.ok(zipperMinor === nodeMinor, 'The running node version "' + nodeMinor + '.x" does not match the node version that zipper was compiled against: "' + zipperMinor + '.x"');
 
 // push all C++ symbols into js module
 for (var k in zipper) { exports[k] = zipper[k]; }


### PR DESCRIPTION
Bugfix versions should be compatible with each other. Compare only the
major and minor version of node.
